### PR TITLE
Request api endpoints

### DIFF
--- a/eth_crowdfund_be/eth_crowdfund_api/src/app.py
+++ b/eth_crowdfund_be/eth_crowdfund_api/src/app.py
@@ -4,6 +4,8 @@ from .config import app_config
 from .models import db
 
 from .views.CampaignView import campaign_api as campaign_blueprint
+from .views.RequestView import request_api as request_blueprint
+
 
 def create_app(env_name):
   """
@@ -18,6 +20,8 @@ def create_app(env_name):
   db.init_app(app)
 
   app.register_blueprint(campaign_blueprint, url_prefix='/api/v1/campaigns')
+  app.register_blueprint(request_blueprint, url_prefix='/api/v1/requests')
+
 
   @app.route('/', methods=['GET'])
   def index():

--- a/eth_crowdfund_be/eth_crowdfund_api/src/models/Campaign.py
+++ b/eth_crowdfund_be/eth_crowdfund_api/src/models/Campaign.py
@@ -19,7 +19,7 @@ class Campaign(db.Model):
   expiration = db.Column(db.DateTime)
   created_at = db.Column(db.DateTime)
   updated_at = db.Column(db.DateTime)
-  # requests = db.relationship('Request', backref='campaigns')
+  requests = db.relationship('Request', cascade="all, delete-orphan")
 
   # class constructor
   def __init__(self, data):

--- a/eth_crowdfund_be/eth_crowdfund_api/src/models/Request.py
+++ b/eth_crowdfund_be/eth_crowdfund_api/src/models/Request.py
@@ -21,7 +21,7 @@ class Request(db.Model):
   approvals = db.Column(db.Integer)
   created_at = db.Column(db.DateTime)
   updated_at = db.Column(db.DateTime)
-  campaign = db.relationship('Campaign', backref='requests')
+  campaign = db.relationship('Campaign')
 
 
 

--- a/eth_crowdfund_be/eth_crowdfund_api/src/views/RequestView.py
+++ b/eth_crowdfund_be/eth_crowdfund_api/src/views/RequestView.py
@@ -1,10 +1,16 @@
 from flask import request, json, Response, Blueprint, g, jsonify
-from ..models.Campaign import Campaign, CampaignSchema
 from ..models.Request import Request, RequestSchema
 
 
 request_api = Blueprint('requests_api', __name__)
 request_schema = RequestSchema()
+
+def custom_response(res, status_code):
+  return Response(
+    mimetype="application/json",
+    response=json.dumps(res),
+    status=status_code
+  )
 
 @request_api.route('/', methods=['POST'])
 def create():
@@ -21,14 +27,6 @@ def create():
   request_data = request_schema.dump(request_info)
   return custom_response(request_data, 201)
 
-
-def custom_response(res, status_code):
-  return Response(
-    mimetype="application/json",
-    response=json.dumps(res),
-    status=status_code
-  )
-
 @request_api.route('/', methods=['GET'])
 def get_all_requests():
   requests = Request.get_all_requests()
@@ -37,6 +35,32 @@ def get_all_requests():
     return custom_response({'error': 'No Requests'}, 404)
 
   request_data = []
-  for request in requests:
-    request_data.append(request_schema.dump(request))
+  for campaign_request in requests:
+    request_data.append(request_schema.dump(campaign_request))
   return custom_response(request_data, 200)
+
+@request_api.route('/<int:request_id>', methods=['GET'])
+def get_a_request(request_id):
+  campaign_request = Request.get_one_request(request_id)
+  if not campaign_request:
+    return custom_response({ 'error': 'Request not found'}, 404)
+  
+  campaign_request_data = request_schema.dump(campaign_request)
+  return custom_response(campaign_request_data, 200)
+
+@request_api.route('/<int:request_id>', methods=['PUT'])
+def update(request_id):
+  req_data = request.get_json()
+  data = request_schema.load(req_data, partial=True)
+
+  campaign_request = Request.get_one_request(request_id)
+  campaign_request.update(data)
+  request_data = request_schema.dump(campaign_request)
+  return custom_response(request_data, 200)
+
+@request_api.route('/<int:request_id>', methods=['DELETE'])
+def delete(request_id):
+  campaign_request = Request.get_one_request(request_id)
+  campaign_request.delete()
+  campaign_request_data = request_schema.dump(campaign_request)
+  return custom_response(campaign_request_data, 200)

--- a/eth_crowdfund_be/eth_crowdfund_api/src/views/RequestView.py
+++ b/eth_crowdfund_be/eth_crowdfund_api/src/views/RequestView.py
@@ -1,0 +1,42 @@
+from flask import request, json, Response, Blueprint, g, jsonify
+from ..models.Campaign import Campaign, CampaignSchema
+from ..models.Request import Request, RequestSchema
+
+
+request_api = Blueprint('requests_api', __name__)
+request_schema = RequestSchema()
+
+@request_api.route('/', methods=['POST'])
+def create():
+  req_data = request.get_json()
+  data = request_schema.load(req_data)
+  # data, error = campaign_schema.load(req_data)
+  # BUT WITH ERROR: the above code threw an error, currently ignoring errors
+  error = None
+  if error:
+    return custom_response(error, 400)
+
+  request_info = Request(data)
+  request_info.save()
+  request_data = request_schema.dump(request_info)
+  return custom_response(request_data, 201)
+
+
+def custom_response(res, status_code):
+  return Response(
+    mimetype="application/json",
+    response=json.dumps(res),
+    status=status_code
+  )
+
+@request_api.route('/', methods=['GET'])
+def get_all_requests():
+  requests = Request.get_all_requests()
+
+  if not requests:
+    return custom_response({'error': 'No Requests'}, 404)
+
+  request_data = []
+  for request in requests:
+    request_data.append(request_schema.dump(request))
+  return custom_response(request_data, 200)


### PR DESCRIPTION
## What's this PR do? 
- Adds request CRUD endpoints (create, get_all, get_one, update, destroy) 
- Updates Campaign with dependent destroy for associated requests

## Where should the reviewer start?
- src/views/RequestView.py

## How should this be manually tested? 
Fire up the server and start hitting those endpoints. 

## Background context? 
- Error handling needs to be improved, but that will be a future step 
- I changed the database relationships to add the dependent destroy. I removed backref from Request and put a db.relationship on Campaign