### PR TITLE
Python Dotenv Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+eth_crowdfund_api/src/.env

--- a/eth_crowdfund_be/eth_crowdfund_api/src/app.py
+++ b/eth_crowdfund_be/eth_crowdfund_api/src/app.py
@@ -1,4 +1,6 @@
 from flask import Flask
+from dotenv import load_dotenv # importing dotenv
+load_dotenv(override=True) # loading the environment variables at app startup and overriding any existing system variables
 
 from .config import app_config
 from .models import db

--- a/eth_crowdfund_be/eth_crowdfund_api/src/config.py
+++ b/eth_crowdfund_be/eth_crowdfund_api/src/config.py
@@ -17,7 +17,7 @@ class Production(object):
 class Testing(object):
   TESTING = True
   JWT_SECRET_KEY = os.getenv('JWT_SECRET_KEY')
-  SQLALCHEMY_DATABASE_URI = "postgresql://postgres:password@localhost/eth_crowdfund_api_db_test"
+  SQLALCHEMY_DATABASE_URI = os.getenv('SQLALCHEMY_TEST_DATABASE_URI')
   SQLALCHEMY_TRACK_MODIFICATIONS=False
 
 

--- a/eth_crowdfund_be/eth_crowdfund_api/src/config.py
+++ b/eth_crowdfund_be/eth_crowdfund_api/src/config.py
@@ -5,13 +5,13 @@ class Development(object):
     DEBUG = True
     TESTING = False
     JWT_SECRET_KEY = os.getenv('JWT_SECRET_KEY')
-    SQLALCHEMY_DATABASE_URI = "postgresql://postgres:password@localhost/eth_crowdfund_api_db"
+    SQLALCHEMY_DATABASE_URI = os.getenv('SQLALCHEMY_DATABASE_URI')
 
 
 class Production(object):
     DEBUG = False
     TESTING = False
-    SQLALCHEMY_DATABASE_URI = "postgresql://postgres:password@localhost/eth_crowdfund_api_db"
+    SQLALCHEMY_DATABASE_URI = os.getenv('SQLALCHEMY_DATABASE_URI')
     JWT_SECRET_KEY = os.getenv('JWT_SECRET_KEY')
 
 class Testing(object):


### PR DESCRIPTION
# What's this PR do?
Adds environment variable functionality so environment variables do not need to be set manually after loading the virtual environment.
# Where should the reviewer start?
`eth_crowdfund_be/eth_crowdfund_api/src/app.py` and `eth_crowdfund_be/eth_crowdfund_api/src/config.py`
# How should this be manually tested?
The reviewer should enter their virtual environment and install python-dotenv with `$ pip install -U python-dotenv`. The reviewer should then create a `.env` file at `eth_crowdfund_be/eth_crowdfund_api/src/.env` with the following:
```
JWT_SECRET_KEY=hhgaghhgsdhdhdd
FLASK_ENV=development
SQLALCHEMY_DATABASE_URI="postgresql://postgres:password@localhost/eth_crowdfund_api_db"
```
The reviewer should then fire up their server and verify all of their endpoints still work without the reviewer manually setting up their environment variables.
# Any background context you want to provide?
This should resolve the annoying issue of having to manually export environment variables every time you activate your virtual environment.
# What are the relevant tickets?
Closes #15 