### PR TITLE
Campaigns by Manager Address

### DIFF
--- a/src/models/Campaign.py
+++ b/src/models/Campaign.py
@@ -1,11 +1,11 @@
-from marshmallow import fields, Schema 
-import datetime 
+from marshmallow import fields, Schema
+import datetime
 from . import db
 from .Request import RequestSchema
 
 class Campaign(db.Model):
 
-  # table name 
+  # table name
   __tablename__ = 'campaigns'
   id = db.Column(db.Integer, primary_key=True)
   name = db.Column(db.String, nullable=False)
@@ -45,29 +45,33 @@ class Campaign(db.Model):
       setattr(self, key, value)
     self.updated_at = datetime.datetime.utcnow()
     db.session.commit()
-  
+
   def delete(self):
     db.session.delete(self)
     db.session.commit()
-  
-  @staticmethod 
+
+  @staticmethod
   def get_all_campaigns():
     return Campaign.query.all()
 
-  @staticmethod 
+  @staticmethod
   def get_one_campaign(id):
     return Campaign.query.get(id)
 
-  @staticmethod 
+  @staticmethod
   def get_campaign_by_name(name):
     return Campaign.query.filter_by(name=name).first()
+
+  @staticmethod
+  def get_campaigns_by_manager(manager):
+      return Campaign.query.filter_by(manager=manager)
 
   def __repr(self):
     return '<id {}>'.format(self.id)
 
 class CampaignSchema(Schema):
   """
-  Campaign Schema 
+  Campaign Schema
   """
   id = fields.Int(dump_only=True)
   name = fields.Str(required=True)

--- a/src/views/CampaignView.py
+++ b/src/views/CampaignView.py
@@ -14,23 +14,23 @@ def hello():
 
 @campaign_api.route('/', methods=['POST'])
 def create():
-  try: 
+  try:
     req_data = request.get_json()
     data = campaign_schema.load(req_data)
-  except ValidationError as err: 
+  except ValidationError as err:
     return custom_response(err.messages, 400)
-  except: 
+  except:
     return custom_response({ "error": "No input data provided" }, 400)
 
   campaign = Campaign(data)
-  campaign.save() 
+  campaign.save()
   campaign_data = campaign_schema.dump(campaign)
   return custom_response(campaign_data, 201)
 
 @campaign_api.route('/<int:campaign_id>', methods=['GET'])
 def get_a_campaign(campaign_id):
   campaign = Campaign.get_one_campaign(campaign_id)
-  if campaign is None: 
+  if campaign is None:
     return custom_response({'error':'Campaign not found'}, 404)
 
   campaign_data = campaign_schema.dump(campaign)
@@ -38,16 +38,16 @@ def get_a_campaign(campaign_id):
 
 @campaign_api.route('/<int:campaign_id>', methods=['PUT'])
 def update(campaign_id):
-  try: 
+  try:
     req_data = request.get_json()
     data = campaign_schema.load(req_data, partial=True)
     campaign = Campaign.get_one_campaign(campaign_id)
     campaign.update(data)
-  except ValidationError as err: 
+  except ValidationError as err:
     return custom_response(err.messages, 400)
-  except exc.IntegrityError as err: 
+  except exc.IntegrityError as err:
     return custom_response({ "error": err.orig.diag.message_detail}, 400)
-  except: 
+  except:
     return custom_response({ "error": "No input data provided" }, 400)
 
   campaign_data = campaign_schema.dump(campaign)
@@ -58,7 +58,7 @@ def update(campaign_id):
 def delete(campaign_id):
   campaign = Campaign.get_one_campaign(campaign_id)
 
-  if campaign is None: 
+  if campaign is None:
     return custom_response({ 'error': 'Campaign not found'}, 404)
 
   campaign.delete()
@@ -76,3 +76,14 @@ def get_all_campaigns():
   for campaign in campaigns:
     campaign_data.append(campaign_schema.dump(campaign))
   return custom_response(campaign_data, 200)
+
+@campaign_api.route('/manager/<manager>', methods=['GET'])
+def get_campaigns_by_manager(manager):
+  campaigns = Campaign.get_campaigns_by_manager(manager)
+  campaign_data = []
+  for campaign in campaigns:
+    campaign_data.append(campaign_schema.dump(campaign))
+  if campaign_data == []:
+    return custom_response({'error': 'The entered manager has no campaigns'}, 404)
+  else:
+    return custom_response(campaign_data, 200)


### PR DESCRIPTION
## What's this PR do?
* Adds the get_campaigns_by_manager_route and static method for Campaign
* Adds a test for happy and sad paths to the get_campaigns_by_manager route
## Where should the reviewer start?
* `src/models/Campaign.py`
* `src/views/CampaignView.py`
* `src/tests/test_campaign.py`
## How should this be manually tested?
* Reviewer can run pytest and verify 8 passing tests
* Reviewer can fire up their server and hit `GET http://localhost:3000/api/v1/campaigns/manager/<manager>` with an existing manager address to view a happy path response and an incorrect manager address to view a sad path response.
## Any background context you want to provide?
* FE requested the ability to receive campaigns by manager address
## What are the relevant tickets?
* Closes #32 